### PR TITLE
Refactor Compiler Context 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_llvm_executable(${EXECUTABLE_NAME}
    src/cli.cpp
    src/CompileHighLevel.cpp
    src/CompilerUtil.cpp
+   src/Scope.cpp
    src/CompilerContext.cpp
    src/SemanticTopLevel.cpp
 

--- a/src/CompileHighLevel.cpp
+++ b/src/CompileHighLevel.cpp
@@ -132,3 +132,8 @@ Function CompileHighLevel::CompileFunctionHeader(std::shared_ptr<FunctionRefNode
 
     return {function, f, n->RetType, n->FunctionName};
 }
+
+ProgramScope CompileHighLevel::getProgramScope()
+{
+    return ProgramScope(this->modules);
+}

--- a/src/CompilerContext.cpp
+++ b/src/CompilerContext.cpp
@@ -1,7 +1,10 @@
 #include <backend/CompilerUtil.h>
 #include "llvm/IR/Module.h"
+#include <backend/Scope.h>
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
+#include <backend/CompilerContext.h>
+// #include <P.h>
 
 CompilerContext::CompilerContext()
 {
@@ -18,57 +21,57 @@ CompilerContext::CompilerContext(std::map<std::string, llvm::Function *> CFuncti
     this->string_type = str_type;
 }
 
-Function CompilerContext::get_function(Tokens name)
-{
-    if (can_get_function(name))
-    {
-        if (modules[current_module.value].func_map.find(name.value) == modules[current_module.value].func_map.end())
-        {
-            auto import_list = modules[current_module.value].imports;
-            for (int i = 0; i < import_list.size(); i++)
-            {
-                if (modules[import_list[i].value].func_map.find(name.value) != modules[current_module.value].func_map.end())
-                {
-                    return modules[import_list[i].value].func_map[name.value];
-                }
-            }
-        }
-        return modules[current_module.value].func_map[name.value];
-    }
-    else
-    {
-        return get_local_function(name);
-    }
-}
+// Function CompilerContext::get_function(Tokens name)
+// {
+//     if (can_get_function(name))
+//     {
+//         if (modules[current_module.value].func_map.find(name.value) == modules[current_module.value].func_map.end())
+//         {
+//             auto import_list = modules[current_module.value].imports;
+//             for (int i = 0; i < import_list.size(); i++)
+//             {
+//                 if (modules[import_list[i].value].func_map.find(name.value) != modules[current_module.value].func_map.end())
+//                 {
+//                     return modules[import_list[i].value].func_map[name.value];
+//                 }
+//             }
+//         }
+//         return modules[current_module.value].func_map[name.value];
+//     }
+//     else
+//     {
+//         return get_local_function(name);
+//     }
+// }
 
-Function CompilerContext::get_local_function(Tokens name)
-{
-    return local_functions[name.value];
-}
-void CompilerContext::add_local_function(Tokens name, Function value)
-{
-    if (this->local_functions.find(name.value) != this->local_functions.end())
-    {
-        local_functions[name.value] = value;
-    }
-    else
-    {
-        local_functions.insert(std::make_pair(name.value, value));
-    }
-}
-void CompilerContext::add_function(Tokens name, Function f)
-{
+// Function CompilerContext::get_local_function(Tokens name)
+// {
+//     return local_functions[name.value];
+// }
+// void CompilerContext::add_local_function(Tokens name, Function value)
+// {
+//     if (this->local_functions.find(name.value) != this->local_functions.end())
+//     {
+//         local_functions[name.value] = value;
+//     }
+//     else
+//     {
+//         local_functions.insert(std::make_pair(name.value, value));
+//     }
+// }
+// void CompilerContext::add_function(Tokens name, Function f)
+// {
 
-    this->func_map.insert(std::make_pair(name.value, f));
-}
+//     this->func_map.insert(std::make_pair(name.value, f));
+// }
 
-Function CompilerContext::get_current()
-{
+// Function CompilerContext::get_current()
+// {
 
-    auto f = this->modules[current_module.value].functions.front();
-    this->modules[current_module.value].functions.pop();
-    return f;
-}
+//     auto f = this->modules[current_module.value].functions.front();
+//     this->modules[current_module.value].functions.pop();
+//     return f;
+// }
 llvm::StructType *CompilerContext::get_string_type(llvm::LLVMContext &context, llvm::IRBuilder<> &builder)
 {
     return string_type;
@@ -214,36 +217,42 @@ OptionalType CompilerContext::get_type(std::shared_ptr<Type> type)
 
 void CompilerContext::AddModule(std::string module_name, CompiledModule module)
 {
-    modules.insert(std::make_pair(module_name, module));
+    std::cout << "compiled module function size: " << module.functions.size() << std::endl;
+
+    modules.insert(std::make_pair(module_name, CompiledModuleClass(module)));
 }
 
-CompiledModule CompilerContext::get_module(Tokens module)
+ProgramScope CompilerContext::getScope()
 {
-    return this->modules[module.value];
+    return ProgramScope(modules);
 }
+// CompiledModule CompilerContext::get_module(Tokens module)
+// {
+//     return this->modules[module.value];
+// }
 
-CompiledModule CompilerContext::get_current_module()
-{
-    return this->modules[current_module.value];
-}
-void CompilerContext::set_current_module(Tokens module_name)
-{
-    this->current_module = module_name;
-}
+// CompiledModule CompilerContext::get_current_module()
+// {
+//     return this->modules[current_module.value];
+// }
+// void CompilerContext::set_current_module(Tokens module_name)
+// {
+//     this->current_module = module_name;
+// }
 
-bool CompilerContext::can_get_function(Tokens name)
-{
-    if (modules[current_module.value].func_map.find(name.value) == modules[current_module.value].func_map.end())
-    {
-        auto import_list = modules[current_module.value].imports;
-        for (int i = 0; i < import_list.size(); i++)
-        {
-            if (modules[import_list[i].value].func_map.find(name.value) != modules[import_list[i].value].func_map.end())
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-    return true;
-}
+// bool CompilerContext::can_get_function(Tokens name)
+// {
+//     if (modules[current_module.value].func_map.find(name.value) == modules[current_module.value].func_map.end())
+//     {
+//         auto import_list = modules[current_module.value].imports;
+//         for (int i = 0; i < import_list.size(); i++)
+//         {
+//             if (modules[import_list[i].value].func_map.find(name.value) != modules[import_list[i].value].func_map.end())
+//             {
+//                 return true;
+//             }
+//         }
+//         return false;
+//     }
+//     return true;
+// }

--- a/src/CompilerContext.cpp
+++ b/src/CompilerContext.cpp
@@ -21,57 +21,6 @@ CompilerContext::CompilerContext(std::map<std::string, llvm::Function *> CFuncti
     this->string_type = str_type;
 }
 
-// Function CompilerContext::get_function(Tokens name)
-// {
-//     if (can_get_function(name))
-//     {
-//         if (modules[current_module.value].func_map.find(name.value) == modules[current_module.value].func_map.end())
-//         {
-//             auto import_list = modules[current_module.value].imports;
-//             for (int i = 0; i < import_list.size(); i++)
-//             {
-//                 if (modules[import_list[i].value].func_map.find(name.value) != modules[current_module.value].func_map.end())
-//                 {
-//                     return modules[import_list[i].value].func_map[name.value];
-//                 }
-//             }
-//         }
-//         return modules[current_module.value].func_map[name.value];
-//     }
-//     else
-//     {
-//         return get_local_function(name);
-//     }
-// }
-
-// Function CompilerContext::get_local_function(Tokens name)
-// {
-//     return local_functions[name.value];
-// }
-// void CompilerContext::add_local_function(Tokens name, Function value)
-// {
-//     if (this->local_functions.find(name.value) != this->local_functions.end())
-//     {
-//         local_functions[name.value] = value;
-//     }
-//     else
-//     {
-//         local_functions.insert(std::make_pair(name.value, value));
-//     }
-// }
-// void CompilerContext::add_function(Tokens name, Function f)
-// {
-
-//     this->func_map.insert(std::make_pair(name.value, f));
-// }
-
-// Function CompilerContext::get_current()
-// {
-
-//     auto f = this->modules[current_module.value].functions.front();
-//     this->modules[current_module.value].functions.pop();
-//     return f;
-// }
 llvm::StructType *CompilerContext::get_string_type(llvm::LLVMContext &context, llvm::IRBuilder<> &builder)
 {
     return string_type;
@@ -226,33 +175,3 @@ ProgramScope CompilerContext::getScope()
 {
     return ProgramScope(modules);
 }
-// CompiledModule CompilerContext::get_module(Tokens module)
-// {
-//     return this->modules[module.value];
-// }
-
-// CompiledModule CompilerContext::get_current_module()
-// {
-//     return this->modules[current_module.value];
-// }
-// void CompilerContext::set_current_module(Tokens module_name)
-// {
-//     this->current_module = module_name;
-// }
-
-// bool CompilerContext::can_get_function(Tokens name)
-// {
-//     if (modules[current_module.value].func_map.find(name.value) == modules[current_module.value].func_map.end())
-//     {
-//         auto import_list = modules[current_module.value].imports;
-//         for (int i = 0; i < import_list.size(); i++)
-//         {
-//             if (modules[import_list[i].value].func_map.find(name.value) != modules[import_list[i].value].func_map.end())
-//             {
-//                 return true;
-//             }
-//         }
-//         return false;
-//     }
-//     return true;
-// }

--- a/src/CompilerUtil.cpp
+++ b/src/CompilerUtil.cpp
@@ -3,9 +3,9 @@
 #include <Frontend/Ast.h>
 #include "llvm/IR/LLVMContext.h"
 #include <memory>
-#include <backend/CompilerUtil.h>
+#include <backend/CompilerContext.h>
 
-TypeOfExpr get_bool_expr_type(std::shared_ptr<ASTNode> n, CompilerContext ctx)
+TypeOfExpr get_bool_expr_type(std::shared_ptr<ASTNode> n, ProgramScope ctx)
 {
     auto c = dynamic_cast<BooleanExprNode *>(n.get());
     if (dynamic_cast<IntegerNode *>(c->lhs.get()) && dynamic_cast<IntegerNode *>(c->rhs.get()))
@@ -21,7 +21,7 @@ TypeOfExpr get_bool_expr_type(std::shared_ptr<ASTNode> n, CompilerContext ctx)
     if (dynamic_cast<BooleanExprNode *>(c->rhs.get()))
         return get_bool_expr_type(c->rhs, ctx);
 }
-TypeOfExpr get_expr_type(std::shared_ptr<ASTNode> n, CompilerContext ctx)
+TypeOfExpr get_expr_type(std::shared_ptr<ASTNode> n, ProgramScope ctx)
 {
     auto c = dynamic_cast<ExprNode *>(n.get());
     if (dynamic_cast<IntegerNode *>(c->lhs.get()) && dynamic_cast<IntegerNode *>(c->rhs.get()))

--- a/src/Scope.cpp
+++ b/src/Scope.cpp
@@ -1,0 +1,92 @@
+#include <backend/Scope.h>
+
+/**
+ * ProgramScope represents the whole scope of the program
+ * and control flow. that "CompiledCOntext" was originally doing
+ */
+ProgramScope::ProgramScope()
+{
+}
+ProgramScope::ProgramScope(std::map<std::string, CompiledModuleClass> modules)
+{
+    this->modules = modules;
+}
+
+void ProgramScope::set_current(Tokens name)
+{
+    this->current_module = modules[name.value];
+}
+Function ProgramScope::get_function(Tokens name)
+{
+    auto global = this->get_global_function(name);
+    if (global.has_value())
+    {
+        return global.value();
+    }
+    else
+    {
+        return local_functions[name.value];
+    }
+}
+
+std::optional<Function> ProgramScope::get_global_function(Tokens name)
+{
+    if (!this->current_module.get_function(name).has_value())
+    {
+        auto import_list = this->current_module.get_import_names();
+        for (int i = 0; i < import_list.size(); i++)
+        {
+            if (modules[import_list[i].value].get_function(name).has_value())
+            {
+                return modules[import_list[i].value].get_function(name).value();
+            }
+        }
+        return {};
+    }
+    return this->current_module.get_function(name);
+}
+Function ProgramScope::get_current_function()
+{
+    return current_module.get_current_function();
+}
+
+void ProgramScope::addLocal(Tokens name, Function function)
+{
+    if (this->local_functions.find(name.value) != this->local_functions.end())
+    {
+        local_functions[name.value] = function;
+    }
+    else
+    {
+        local_functions.insert(std::make_pair(name.value, function));
+    }
+}
+CompiledModuleClass::CompiledModuleClass()
+{
+}
+
+CompiledModuleClass::CompiledModuleClass(CompiledModule CompiledModule)
+{
+    this->compiled_module = compiled_module;
+}
+
+std::optional<Function> CompiledModuleClass::get_function(Tokens name)
+{
+    if (this->compiled_module.func_map.find(name.value) == this->compiled_module.func_map.find(name.value))
+    {
+        return {};
+    }
+    return this->compiled_module.func_map[name.value];
+}
+
+std::vector<Tokens> CompiledModuleClass::get_import_names()
+{
+    return compiled_module.imports;
+}
+
+Function CompiledModuleClass::get_current_function()
+{
+    auto f = this->compiled_module.functions.front();
+    compiled_module.functions.pop();
+    return f;
+}

--- a/src/Scope.cpp
+++ b/src/Scope.cpp
@@ -67,7 +67,8 @@ CompiledModuleClass::CompiledModuleClass()
 
 CompiledModuleClass::CompiledModuleClass(CompiledModule CompiledModule)
 {
-    this->compiled_module = compiled_module;
+    this->compiled_module = CompiledModule;
+    std::cout << "compiled module function size: " << compiled_module.functions.size() << std::endl;
 }
 
 std::optional<Function> CompiledModuleClass::get_function(Tokens name)
@@ -86,6 +87,7 @@ std::vector<Tokens> CompiledModuleClass::get_import_names()
 
 Function CompiledModuleClass::get_current_function()
 {
+    std::cout << this->compiled_module.functions.size() << std::endl;
     auto f = this->compiled_module.functions.front();
     compiled_module.functions.pop();
     return f;

--- a/src/include/backend/CompilerContext.h
+++ b/src/include/backend/CompilerContext.h
@@ -1,0 +1,79 @@
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include <map>
+#include <iostream>
+#include <queue>
+#include "llvm/IR/LLVMContext.h"
+#include <backend/Scope.h>
+#include <Frontend/Token.h>
+#include <Frontend/Ast.h>
+
+#ifndef OPTIONAL_TYPE_H
+#define OPTIONAL_TYPE_H
+class OptionalType
+{
+public:
+    llvm::StructType *type;
+    llvm::Type *inner;
+    OptionalType();
+    OptionalType(llvm::LLVMContext &context, llvm::IRBuilder<> &builder, llvm::Type *inner);
+    llvm::Value *set_loaded_value(llvm::Value *value, llvm::IRBuilder<> &builder);
+    llvm::Value *get_value(llvm::IRBuilder<> &builder);
+    llvm::Value *get_none(llvm::IRBuilder<> &builder);
+};
+#endif
+
+#ifndef CONTEXT_H
+#define CONTEXT_H
+
+// #ifndef CONTEXT_H
+// #define CONTEXT_H
+class CompilerContext
+{
+public:
+    std::map<std::string, Function> func_map;
+    std::map<std::string, CompiledModuleClass> modules;
+    std::map<std::string, llvm::Function *> CFunctions;
+    std::map<TokenType, OptionalType> NativeTypes;
+    Tokens current_module;
+    // std::map<std::string, llvm::Type *> types;
+    // std::map<TokenType, OptionalType> types;
+    std::vector<llvm::StructType *> lists;
+    // std::map<std::string, Function> local_functions;
+    llvm::StructType *string_type;
+    CompilerContext();
+    CompilerContext(std::map<std::string, llvm::Function *> CFunctions,
+                    std::map<TokenType, OptionalType> NativeTypes,
+                    llvm::StructType *str_type);
+    // Function get_function(Tokens name);
+    // Function get_local_function(Tokens name);
+    // void add_local_function(Tokens name, Function function);
+    // void add_function(Tokens name, Function f);
+    // Function get_current();
+    // void compile_cfunctions(llvm::Module &module, llvm::LLVMContext &context, llvm::IRBuilder<> &builder);
+    llvm::StructType *get_string_type(llvm::LLVMContext &context, llvm::IRBuilder<> &builder);
+    llvm::Type *compile_Type(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<Type> ty);
+    llvm::FunctionType *compile_Function_Type(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<FunctionRefNode> n);
+
+    OptionalType compile_Type_Optional(std::shared_ptr<Type> ty);
+    Thunks get_thunk_types(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<FunctionRefNode> n);
+
+    OptionalType get_integer_type();
+    OptionalType get_float_type();
+    OptionalType get_string_type();
+    OptionalType get_boolean_type();
+    OptionalType get_byte_type();
+    OptionalType get_type(std::shared_ptr<Type> type);
+
+    void AddModule(std::string module_name, CompiledModule module);
+    ProgramScope getScope();
+    // CompiledModule get_module(Tokens module);
+    // CompiledModule get_current_module();
+    // void set_current_module(Tokens module_name);
+    // bool can_get_function(Tokens name);
+};
+#endif
+
+TypeOfExpr get_expr_type(std::shared_ptr<ASTNode> n, ProgramScope ctx);
+TypeOfExpr get_bool_expr_type(std::shared_ptr<ASTNode> n, ProgramScope ctx);

--- a/src/include/backend/CompilerUtil.h
+++ b/src/include/backend/CompilerUtil.h
@@ -2,24 +2,25 @@
 #include "llvm/IR/IRBuilder.h"
 #include <map>
 #include <iostream>
-#include <Frontend/Ast.h>
 #include <queue>
+#include <Frontend/Token.h>
+#include <Frontend/Ast.h>
 #include "llvm/IR/LLVMContext.h"
 
-#ifndef OPTIONAL_TYPE_H
-#define OPTIONAL_TYPE_H
-class OptionalType
-{
-public:
-    llvm::StructType *type;
-    llvm::Type *inner;
-    OptionalType();
-    OptionalType(llvm::LLVMContext &context, llvm::IRBuilder<> &builder, llvm::Type *inner);
-    llvm::Value *set_loaded_value(llvm::Value *value, llvm::IRBuilder<> &builder);
-    llvm::Value *get_value(llvm::IRBuilder<> &builder);
-    llvm::Value *get_none(llvm::IRBuilder<> &builder);
-};
-#endif
+// #ifndef OPTIONAL_TYPE_H
+// #define OPTIONAL_TYPE_H
+// class OptionalType
+// {
+// public:
+//     llvm::StructType *type;
+//     llvm::Type *inner;
+//     OptionalType();
+//     OptionalType(llvm::LLVMContext &context, llvm::IRBuilder<> &builder, llvm::Type *inner);
+//     llvm::Value *set_loaded_value(llvm::Value *value, llvm::IRBuilder<> &builder);
+//     llvm::Value *get_value(llvm::IRBuilder<> &builder);
+//     llvm::Value *get_none(llvm::IRBuilder<> &builder);
+// };
+// #endif
 #ifndef TYPE_OF_EXPR_H
 #define TYPE_OF_EXPR_H
 enum TypeOfExpr
@@ -64,55 +65,56 @@ struct CompiledModule
 };
 #endif
 
-#ifndef CONTEXT_H
-#define CONTEXT_H
+// #ifndef CONTEXT_H
+// #define CONTEXT_H
 
-class CompilerContext
-{
-public:
-    std::map<std::string, Function> func_map;
-    std::map<std::string, CompiledModule> modules;
-    std::map<std::string, llvm::Function *> CFunctions;
-    std::map<TokenType, OptionalType> NativeTypes;
-    Tokens current_module;
-    // std::map<std::string, llvm::Type *> types;
-    // std::map<TokenType, OptionalType> types;
-    std::vector<llvm::StructType *> lists;
-    std::map<std::string, Function> local_functions;
-    llvm::StructType *string_type;
-    CompilerContext();
-    CompilerContext(std::map<std::string, llvm::Function *> CFunctions,
-                    std::map<TokenType, OptionalType> NativeTypes,
-                    llvm::StructType *str_type);
-    Function get_function(Tokens name);
-    Function get_local_function(Tokens name);
-    void add_local_function(Tokens name, Function function);
-    void add_function(Tokens name, Function f);
-    Function get_current();
-    // void compile_cfunctions(llvm::Module &module, llvm::LLVMContext &context, llvm::IRBuilder<> &builder);
-    llvm::StructType *get_string_type(llvm::LLVMContext &context, llvm::IRBuilder<> &builder);
-    llvm::Type *compile_Type(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<Type> ty);
-    llvm::FunctionType *compile_Function_Type(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<FunctionRefNode> n);
+// class CompilerContext
+// {
+// public:
+//     std::map<std::string, Function> func_map;
+//     std::map<std::string, CompiledModuleClass> modules;
+//     std::map<std::string, llvm::Function *> CFunctions;
+//     std::map<TokenType, OptionalType> NativeTypes;
+//     Tokens current_module;
+//     // std::map<std::string, llvm::Type *> types;
+//     // std::map<TokenType, OptionalType> types;
+//     std::vector<llvm::StructType *> lists;
+//     std::map<std::string, Function> local_functions;
+//     llvm::StructType *string_type;
+//     CompilerContext();
+//     CompilerContext(std::map<std::string, llvm::Function *> CFunctions,
+//                     std::map<TokenType, OptionalType> NativeTypes,
+//                     llvm::StructType *str_type);
+//     // Function get_function(Tokens name);
+//     // Function get_local_function(Tokens name);
+//     // void add_local_function(Tokens name, Function function);
+//     // void add_function(Tokens name, Function f);
+//     // Function get_current();
+//     // void compile_cfunctions(llvm::Module &module, llvm::LLVMContext &context, llvm::IRBuilder<> &builder);
+//     llvm::StructType *get_string_type(llvm::LLVMContext &context, llvm::IRBuilder<> &builder);
+//     llvm::Type *compile_Type(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<Type> ty);
+//     llvm::FunctionType *compile_Function_Type(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<FunctionRefNode> n);
 
-    OptionalType compile_Type_Optional(std::shared_ptr<Type> ty);
-    Thunks get_thunk_types(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<FunctionRefNode> n);
+//     OptionalType compile_Type_Optional(std::shared_ptr<Type> ty);
+//     Thunks get_thunk_types(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<FunctionRefNode> n);
 
-    OptionalType get_integer_type();
-    OptionalType get_float_type();
-    OptionalType get_string_type();
-    OptionalType get_boolean_type();
-    OptionalType get_byte_type();
-    OptionalType get_type(std::shared_ptr<Type> type);
+//     OptionalType get_integer_type();
+//     OptionalType get_float_type();
+//     OptionalType get_string_type();
+//     OptionalType get_boolean_type();
+//     OptionalType get_byte_type();
+//     OptionalType get_type(std::shared_ptr<Type> type);
 
-    void AddModule(std::string module_name, CompiledModule module);
-    CompiledModule get_module(Tokens module);
-    CompiledModule get_current_module();
-    void set_current_module(Tokens module_name);
-    bool can_get_function(Tokens name);
-};
-#endif
+//     void AddModule(std::string module_name, CompiledModule module);
+//     ProgramScope getScope();
+//     // CompiledModule get_module(Tokens module);
+//     // CompiledModule get_current_module();
+//     // void set_current_module(Tokens module_name);
+//     // bool can_get_function(Tokens name);
+// };
+// #endif
 // llvm::Type *compileType(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<Type> ty, CompilerContext &ctx);
 // llvm::FunctionType *CompileFunctionType(llvm::IRBuilder<> &builder, llvm::LLVMContext &context, std::shared_ptr<FunctionRefNode> n, CompilerContext &ctx);
 
-TypeOfExpr get_expr_type(std::shared_ptr<ASTNode> n, CompilerContext ctx);
-TypeOfExpr get_bool_expr_type(std::shared_ptr<ASTNode> n, CompilerContext ctx);
+// TypeOfExpr get_expr_type(std::shared_ptr<ASTNode> n, CompilerContext ctx);
+// TypeOfExpr get_bool_expr_type(std::shared_ptr<ASTNode> n, CompilerContext ctx);

--- a/src/include/backend/Scope.h
+++ b/src/include/backend/Scope.h
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <optional>
 #include <backend/CompilerUtil.h>
+#include <Frontend/Token.h>
 
 #ifndef COMPILED_MODULE_CLASS_H
 #define COMPILED_MODULE_CLASS_H

--- a/src/include/backend/Scope.h
+++ b/src/include/backend/Scope.h
@@ -1,0 +1,41 @@
+#include <map>
+#include <iostream>
+#include <optional>
+#include <backend/CompilerUtil.h>
+
+#ifndef COMPILED_MODULE_CLASS_H
+#define COMPILED_MODULE_CLASS_H
+class CompiledModuleClass
+{
+private:
+    CompiledModule compiled_module;
+
+public:
+    CompiledModuleClass();
+    CompiledModuleClass(CompiledModule CompiledModule);
+    std::optional<Function> get_function(Tokens name);
+    std::vector<Tokens> get_import_names();
+    Function get_current_function();
+};
+#endif
+
+#ifndef PROGRAM_SCOPE_H
+#define PROGRAM_SCOPE_H
+class ProgramScope
+{
+private:
+    CompiledModuleClass current_module;
+    std::map<std::string, Function> local_functions;
+
+public:
+    std::map<std::string, CompiledModuleClass> modules;
+    ProgramScope();
+    ProgramScope(std::map<std::string, CompiledModuleClass> modules);
+    std::optional<Function> get_global_function(Tokens name);
+    void set_current(Tokens name);
+    Function get_function(Tokens name);
+    Function get_current_function();
+    void addLocal(Tokens name, Function function);
+};
+
+#endif

--- a/src/include/visitor.h
+++ b/src/include/visitor.h
@@ -135,7 +135,7 @@ public:
 
     Function CompileFunctionHeader(std::shared_ptr<FunctionRefNode> n);
     ProgramScope getProgramScope();
-}
+};
 
 #endif
 

--- a/src/include/visitor.h
+++ b/src/include/visitor.h
@@ -2,7 +2,7 @@
 
 #include "llvm/IR/Module.h"
 #include "llvm/IR/IRBuilder.h"
-
+#include <backend/Scope.h>
 #include <Frontend/Ast.h>
 #include <map>
 #include <memory>
@@ -104,10 +104,14 @@ public:
     void Visit(ProgramNode *node) override;
 };
 #endif
+
 #ifndef COMPILER_H
 #define COMPILER_H
 class CompileHighLevel : public Visitor
 {
+private:
+    std::map<std::string, CompiledModuleClass> modules;
+
 public:
     llvm::Module &module;
     std::vector<std::shared_ptr<ASTNode>> functions;
@@ -130,9 +134,11 @@ public:
     void Visit(ProgramNode *node) override;
 
     Function CompileFunctionHeader(std::shared_ptr<FunctionRefNode> n);
-};
+    ProgramScope getProgramScope();
+}
 
 #endif
+
 #ifndef COMPILE_STATEMENT_H
 #define COMPILE_STATEMENT_H
 class CompileStatement : public Visitor

--- a/src/include/visitor.h
+++ b/src/include/visitor.h
@@ -6,6 +6,7 @@
 #include <Frontend/Ast.h>
 #include <map>
 #include <memory>
+#include <backend/CompilerContext.h>
 #include <backend/CompilerUtil.h>
 
 #ifndef SEMANTUC_FUCN
@@ -149,6 +150,7 @@ public:
     CompilerContext compiler_context;
     llvm::IRBuilder<> &builder;
     llvm::LLVMContext &context;
+    ProgramScope program_scope;
     CompileStatement(llvm::Module &module, llvm::IRBuilder<> &builder, llvm::LLVMContext &context, CompilerContext compiler_context);
     void Visit(ASTNode *node) override;
     void Visit(FunctionNode *node) override;
@@ -176,11 +178,14 @@ private:
 
 public:
     llvm::Module &module;
+    ProgramScope program;
     // std::map<std::string, Function> func_map;
     CompilerContext compiler_context;
     llvm::IRBuilder<> &builder;
     llvm::LLVMContext &context;
-    CompileExpr(llvm::Module &module, llvm::IRBuilder<> &builder, llvm::LLVMContext &context, CompilerContext compiler_context);
+    CompileExpr(llvm::Module &module, llvm::IRBuilder<> &builder, llvm::LLVMContext &context,
+                CompilerContext compiler_context,
+                ProgramScope program);
     llvm::Value *IntMathExpression(llvm::Value *lhs, Tokens op, llvm::Value *rhs);
     llvm::Value *FloatMathExpression(llvm::Value *lhs, Tokens op, llvm::Value *rhs);
     llvm::Value *BoolIntMathExpr(llvm::Value *lhs, Tokens op, llvm::Value *rhs);


### PR DESCRIPTION
delegated the scope work Compiler Context did to ProgramScope 
which handles a wrapper class over Compiled Module.

next thing I should do is the same but for types. when ever I get a round to it. 